### PR TITLE
fix: Make eslint warn instead of error. Add prettierrc

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+ESLINT_NO_DEV_ERRORS=true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,31 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": false,
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 4,
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "*.json",
+      "options": {
+        "tabWidth": 2
+      }
+    },
+    {
+      "files": "*.scss",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Description**
One road block I frequently see when pairing with potential candidates is the eslint errors that block compilation significantly slowing down speed of development. Pair that with no prettier rules setup (or a local prettier running that runs counter to our eslint rules), and things get frustrating. This adds a prettierrc and makes it so eslint will only warn in the console instead of breaking compilation.